### PR TITLE
Implement standalone backend service and modify frontend to use backend instead of localStorage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # memo-list
 一个具有自动安排复习功能的to-do list应用
 
+## Project Structure
+
+- `memo-frontend`: Next.js frontend application
+- `memo-backend`: standalone backend API service for task management + memory-curve scheduling
+
 ## 如何进行贡献？
 
 1. 请将仓库`fork`一份到自己的名下。

--- a/README.md
+++ b/README.md
@@ -6,6 +6,28 @@
 - `memo-frontend`: Next.js frontend application
 - `memo-backend`: standalone backend API service for task management + memory-curve scheduling
 
+## Run Locally
+
+1. Start backend
+
+```bash
+cd memo-backend
+npm install
+npm run dev
+```
+
+Backend default URL: `http://localhost:4000`
+
+2. Start frontend (new terminal)
+
+```bash
+cd memo-frontend
+npm install
+NEXT_PUBLIC_API_BASE_URL=http://localhost:4000 npm run dev
+```
+
+Frontend default URL: `http://localhost:3000`
+
 ## 如何进行贡献？
 
 1. 请将仓库`fork`一份到自己的名下。

--- a/memo-backend/.gitignore
+++ b/memo-backend/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+data/*.json

--- a/memo-backend/README.md
+++ b/memo-backend/README.md
@@ -1,0 +1,87 @@
+# memo-backend
+
+Standalone backend service for Memory Curve To-Do.
+
+## Features
+
+- Daily task CRUD APIs
+- Recurring task generation (daily, weekly, monthly, weekdays)
+- Learning task completion workflow with review-task generation
+- Ebbinghaus review intervals: 1, 3, 7, 15, 30 days
+- Mastery-based dynamic rescheduling for pending review tasks
+- File persistence at data/memory-curve-db.json
+
+## Run locally
+
+1. Install dependencies
+
+npm install
+
+2. Start dev server
+
+npm run dev
+
+3. Default service URL
+
+http://localhost:4000
+
+## API
+
+### GET /health
+
+Returns service status.
+
+### GET /api/tasks
+
+Query params:
+- date: YYYY-MM-DD
+- from: YYYY-MM-DD
+- to: YYYY-MM-DD
+- includeCompleted: true or false (default true)
+
+### POST /api/tasks
+
+Body:
+{
+  "title": "Read chapter 1",
+  "frequency": "daily",
+  "reminderTime": "09:00",
+  "isLearning": true,
+  "notes": "Focus on key concepts",
+  "dueDate": "2026-04-23"
+}
+
+### GET /api/tasks/:id
+
+Returns one task.
+
+### PATCH /api/tasks/:id
+
+Partial updates for title, frequency, reminderTime, isLearning, notes, dueDate.
+
+### DELETE /api/tasks/:id
+
+Deletes one task.
+
+### POST /api/tasks/:id/complete
+
+Normal task completion:
+{}
+
+Learning source completion:
+{
+  "learnedContent": "I learned topic X"
+}
+
+Review task completion:
+{
+  "mastery": "good"
+}
+
+Response:
+{
+  "task": {},
+  "createdReviews": [],
+  "adjustedReviews": [],
+  "nextRecurringTask": {}
+}

--- a/memo-backend/package-lock.json
+++ b/memo-backend/package-lock.json
@@ -1,0 +1,1562 @@
+{
+  "name": "memo-backend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "memo-backend",
+      "version": "0.1.0",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "express": "^4.21.2",
+        "zod": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/cors": "^2.8.17",
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.17.9",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/memo-backend/package.json
+++ b/memo-backend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "memo-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.21.2",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.17.9",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/memo-backend/src/app.ts
+++ b/memo-backend/src/app.ts
@@ -1,0 +1,112 @@
+import express, { type Request, type Response } from 'express';
+import cors from 'cors';
+import { ZodError } from 'zod';
+import {
+  completeTask,
+  createTask,
+  deleteTask,
+  getTaskById,
+  listTasks,
+  updateTask,
+} from './task-service.js';
+import { NotFoundError, ValidationError } from './errors.js';
+import {
+  completeTaskSchema,
+  createTaskSchema,
+  listTaskQuerySchema,
+  updateTaskSchema,
+} from './validation.js';
+
+export const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+app.get('/health', (_req: Request, res: Response) => {
+  res.json({ ok: true, service: 'memo-backend' });
+});
+
+app.get('/api/tasks', async (req: Request, res: Response) => {
+  try {
+    const parsed = listTaskQuerySchema.parse(req.query);
+    const tasks = await listTasks({
+      date: parsed.date,
+      from: parsed.from,
+      to: parsed.to,
+      includeCompleted: parsed.includeCompleted,
+    });
+    res.json({ tasks });
+  } catch (error) {
+    handleError(error, res);
+  }
+});
+
+app.post('/api/tasks', async (req: Request, res: Response) => {
+  try {
+    const payload = createTaskSchema.parse(req.body);
+    const task = await createTask(payload);
+    res.status(201).json({ task });
+  } catch (error) {
+    handleError(error, res);
+  }
+});
+
+app.get('/api/tasks/:id', async (req: Request, res: Response) => {
+  try {
+    const task = await getTaskById(req.params.id);
+    res.json({ task });
+  } catch (error) {
+    handleError(error, res);
+  }
+});
+
+app.patch('/api/tasks/:id', async (req: Request, res: Response) => {
+  try {
+    const payload = updateTaskSchema.parse(req.body);
+    const task = await updateTask(req.params.id, payload);
+    res.json({ task });
+  } catch (error) {
+    handleError(error, res);
+  }
+});
+
+app.delete('/api/tasks/:id', async (req: Request, res: Response) => {
+  try {
+    await deleteTask(req.params.id);
+    res.json({ ok: true });
+  } catch (error) {
+    handleError(error, res);
+  }
+});
+
+app.post('/api/tasks/:id/complete', async (req: Request, res: Response) => {
+  try {
+    const payload = completeTaskSchema.parse(req.body);
+    const result = await completeTask(req.params.id, payload);
+    res.json(result);
+  } catch (error) {
+    handleError(error, res);
+  }
+});
+
+function handleError(error: unknown, res: Response): void {
+  if (error instanceof ZodError) {
+    res.status(400).json({
+      error: 'Invalid request payload.',
+      details: error.issues,
+    });
+    return;
+  }
+
+  if (error instanceof ValidationError) {
+    res.status(400).json({ error: error.message });
+    return;
+  }
+
+  if (error instanceof NotFoundError) {
+    res.status(404).json({ error: error.message });
+    return;
+  }
+
+  res.status(500).json({ error: 'Internal server error.' });
+}

--- a/memo-backend/src/db.ts
+++ b/memo-backend/src/db.ts
@@ -1,0 +1,27 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { TaskDatabase } from './types.js';
+
+const DATA_DIR = path.join(process.cwd(), 'data');
+const DB_FILE = path.join(DATA_DIR, 'memory-curve-db.json');
+
+const EMPTY_DB: TaskDatabase = {
+  tasks: [],
+};
+
+export async function readDb(): Promise<TaskDatabase> {
+  try {
+    const raw = await readFile(DB_FILE, 'utf8');
+    const parsed = JSON.parse(raw) as TaskDatabase;
+    return {
+      tasks: Array.isArray(parsed.tasks) ? parsed.tasks : [],
+    };
+  } catch {
+    return EMPTY_DB;
+  }
+}
+
+export async function writeDb(db: TaskDatabase): Promise<void> {
+  await mkdir(DATA_DIR, { recursive: true });
+  await writeFile(DB_FILE, JSON.stringify(db, null, 2), 'utf8');
+}

--- a/memo-backend/src/errors.ts
+++ b/memo-backend/src/errors.ts
@@ -1,0 +1,2 @@
+export class ValidationError extends Error {}
+export class NotFoundError extends Error {}

--- a/memo-backend/src/index.ts
+++ b/memo-backend/src/index.ts
@@ -1,0 +1,7 @@
+import { app } from './app.js';
+
+const port = Number(process.env.PORT || 4000);
+
+app.listen(port, () => {
+  console.log(`memo-backend running on port ${port}`);
+});

--- a/memo-backend/src/task-service.ts
+++ b/memo-backend/src/task-service.ts
@@ -1,0 +1,415 @@
+import crypto from 'node:crypto';
+import { readDb, writeDb } from './db.js';
+import { NotFoundError, ValidationError } from './errors.js';
+import type {
+  CompleteTaskInput,
+  CompleteTaskResult,
+  CreateTaskInput,
+  MasteryLevel,
+  Task,
+  TaskFrequency,
+  UpdateTaskInput,
+} from './types.js';
+
+const REVIEW_INTERVAL_DAYS = [1, 3, 7, 15, 30] as const;
+
+const FREQUENCIES: TaskFrequency[] = ['once', 'daily', 'weekly', 'monthly', 'weekdays'];
+const MASTERY_LEVELS: MasteryLevel[] = ['good', 'fair', 'poor'];
+
+function toDateOnly(isoOrDate: string): string {
+  return isoOrDate.split('T')[0];
+}
+
+function isDateOnly(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function addDays(dateOnly: string, days: number): string {
+  const date = new Date(`${dateOnly}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return toDateOnly(date.toISOString());
+}
+
+function compareDateOnly(a: string, b: string): number {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+function nextDueDate(currentDueDate: string, frequency: TaskFrequency): string {
+  if (frequency === 'daily') return addDays(currentDueDate, 1);
+  if (frequency === 'weekly') return addDays(currentDueDate, 7);
+
+  if (frequency === 'monthly') {
+    const date = new Date(`${currentDueDate}T00:00:00.000Z`);
+    date.setUTCMonth(date.getUTCMonth() + 1);
+    return toDateOnly(date.toISOString());
+  }
+
+  if (frequency === 'weekdays') {
+    let candidate = addDays(currentDueDate, 1);
+    while (true) {
+      const weekday = new Date(`${candidate}T00:00:00.000Z`).getUTCDay();
+      if (weekday !== 0 && weekday !== 6) return candidate;
+      candidate = addDays(candidate, 1);
+    }
+  }
+
+  return currentDueDate;
+}
+
+function masteryMultiplier(mastery?: MasteryLevel): number {
+  if (mastery === 'good') return 1.25;
+  if (mastery === 'poor') return 0.6;
+  return 1;
+}
+
+function adjustedInterval(base: number, mastery?: MasteryLevel): number {
+  return Math.max(1, Math.round(base * masteryMultiplier(mastery)));
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function newId(): string {
+  return crypto.randomUUID();
+}
+
+function assertValidFrequency(value: unknown): asserts value is TaskFrequency {
+  if (!FREQUENCIES.includes(value as TaskFrequency)) {
+    throw new ValidationError('Invalid frequency.');
+  }
+}
+
+function assertValidMastery(value: unknown): asserts value is MasteryLevel {
+  if (!MASTERY_LEVELS.includes(value as MasteryLevel)) {
+    throw new ValidationError('Invalid mastery level.');
+  }
+}
+
+function assertCreateInput(input: CreateTaskInput): void {
+  if (!input.title?.trim()) {
+    throw new ValidationError('Task title is required.');
+  }
+
+  assertValidFrequency(input.frequency);
+
+  if (!isDateOnly(input.dueDate)) {
+    throw new ValidationError('dueDate must use YYYY-MM-DD format.');
+  }
+}
+
+function sortTasks(tasks: Task[]): Task[] {
+  return [...tasks].sort((a, b) => {
+    const dateDiff = compareDateOnly(a.dueDate, b.dueDate);
+    if (dateDiff !== 0) return dateDiff;
+    if (a.createdAt === b.createdAt) return 0;
+    return a.createdAt < b.createdAt ? -1 : 1;
+  });
+}
+
+export async function listTasks(filters?: {
+  date?: string;
+  from?: string;
+  to?: string;
+  includeCompleted?: boolean;
+}): Promise<Task[]> {
+  const db = await readDb();
+  let tasks = sortTasks(db.tasks);
+
+  if (filters?.date) {
+    if (!isDateOnly(filters.date)) {
+      throw new ValidationError('date must use YYYY-MM-DD format.');
+    }
+    tasks = tasks.filter((task) => task.dueDate === filters.date);
+  }
+
+  if (filters?.from) {
+    if (!isDateOnly(filters.from)) {
+      throw new ValidationError('from must use YYYY-MM-DD format.');
+    }
+    tasks = tasks.filter((task) => compareDateOnly(task.dueDate, filters.from as string) >= 0);
+  }
+
+  if (filters?.to) {
+    if (!isDateOnly(filters.to)) {
+      throw new ValidationError('to must use YYYY-MM-DD format.');
+    }
+    tasks = tasks.filter((task) => compareDateOnly(task.dueDate, filters.to as string) <= 0);
+  }
+
+  if (!filters?.includeCompleted) {
+    tasks = tasks.filter((task) => !task.completed);
+  }
+
+  return tasks;
+}
+
+export async function getTaskById(id: string): Promise<Task> {
+  const db = await readDb();
+  const task = db.tasks.find((item) => item.id === id);
+  if (!task) {
+    throw new NotFoundError('Task not found.');
+  }
+  return task;
+}
+
+export async function createTask(input: CreateTaskInput): Promise<Task> {
+  assertCreateInput(input);
+
+  const now = nowIso();
+  const newTask: Task = {
+    id: newId(),
+    title: input.title.trim(),
+    frequency: input.frequency,
+    reminderTime: input.reminderTime ?? null,
+    isLearning: Boolean(input.isLearning),
+    notes: input.notes?.trim() || undefined,
+    completed: false,
+    dueDate: input.dueDate,
+    createdAt: now,
+    updatedAt: now,
+    taskKind: input.isLearning ? 'learning_source' : 'standard',
+    parentTaskId: null,
+  };
+
+  const db = await readDb();
+  db.tasks.push(newTask);
+  await writeDb(db);
+
+  return newTask;
+}
+
+export async function updateTask(id: string, updates: UpdateTaskInput): Promise<Task> {
+  const db = await readDb();
+  const index = db.tasks.findIndex((task) => task.id === id);
+  if (index === -1) {
+    throw new NotFoundError('Task not found.');
+  }
+
+  if (updates.frequency !== undefined) {
+    assertValidFrequency(updates.frequency);
+  }
+
+  if (updates.dueDate !== undefined && !isDateOnly(updates.dueDate)) {
+    throw new ValidationError('dueDate must use YYYY-MM-DD format.');
+  }
+
+  if (updates.title !== undefined && !updates.title.trim()) {
+    throw new ValidationError('Task title cannot be empty.');
+  }
+
+  const existing = db.tasks[index];
+  const next: Task = {
+    ...existing,
+    ...updates,
+    title: updates.title !== undefined ? updates.title.trim() : existing.title,
+    notes: updates.notes !== undefined ? updates.notes.trim() || undefined : existing.notes,
+    reminderTime: updates.reminderTime !== undefined ? updates.reminderTime : existing.reminderTime,
+    updatedAt: nowIso(),
+  };
+
+  if (next.taskKind !== 'learning_review') {
+    next.taskKind = next.isLearning ? 'learning_source' : 'standard';
+  }
+
+  db.tasks[index] = next;
+  await writeDb(db);
+
+  return next;
+}
+
+export async function deleteTask(id: string): Promise<void> {
+  const db = await readDb();
+  const before = db.tasks.length;
+  db.tasks = db.tasks.filter((task) => task.id !== id);
+
+  if (db.tasks.length === before) {
+    throw new NotFoundError('Task not found.');
+  }
+
+  await writeDb(db);
+}
+
+function createReviewTasks(options: {
+  sourceTask: Task;
+  completionDate: string;
+  learnedContent: string;
+  mastery?: MasteryLevel;
+}): Task[] {
+  const now = nowIso();
+  const seriesId = options.sourceTask.seriesId || newId();
+  const created: Task[] = [];
+  let previousDate = options.completionDate;
+
+  for (let idx = 0; idx < REVIEW_INTERVAL_DAYS.length; idx += 1) {
+    const base = REVIEW_INTERVAL_DAYS[idx];
+    const planned = addDays(options.completionDate, adjustedInterval(base, options.mastery));
+    const dueDate = compareDateOnly(planned, previousDate) <= 0 ? addDays(previousDate, 1) : planned;
+
+    const reviewTask: Task = {
+      id: newId(),
+      title: `Review: ${options.sourceTask.title}`,
+      frequency: 'once',
+      reminderTime: options.sourceTask.reminderTime ?? null,
+      isLearning: true,
+      notes: options.sourceTask.notes,
+      completed: false,
+      dueDate,
+      createdAt: now,
+      updatedAt: now,
+      taskKind: 'learning_review',
+      parentTaskId: options.sourceTask.id,
+      seriesId,
+      reviewStep: idx + 1,
+      learningContent: options.learnedContent,
+    };
+
+    created.push(reviewTask);
+    previousDate = dueDate;
+  }
+
+  options.sourceTask.seriesId = seriesId;
+  options.sourceTask.learningContent = options.learnedContent;
+
+  return created;
+}
+
+function adjustPendingReviews(options: {
+  tasks: Task[];
+  seriesId: string;
+  completedReviewStep: number;
+  completedAtDate: string;
+  mastery: MasteryLevel;
+}): Task[] {
+  const pending = options.tasks
+    .filter((task) => {
+      if (task.taskKind !== 'learning_review') return false;
+      if (task.seriesId !== options.seriesId) return false;
+      if (task.completed) return false;
+      return (task.reviewStep ?? 0) > options.completedReviewStep;
+    })
+    .sort((a, b) => (a.reviewStep ?? 0) - (b.reviewStep ?? 0));
+
+  const changed: Task[] = [];
+  let previousDate = options.completedAtDate;
+
+  for (const review of pending) {
+    const stepIndex = Math.max(0, (review.reviewStep ?? 1) - 1);
+    const base = REVIEW_INTERVAL_DAYS[Math.min(stepIndex, REVIEW_INTERVAL_DAYS.length - 1)];
+    const proposed = addDays(options.completedAtDate, adjustedInterval(base, options.mastery));
+    const dueDate = compareDateOnly(proposed, previousDate) <= 0 ? addDays(previousDate, 1) : proposed;
+
+    if (review.dueDate !== dueDate) {
+      review.dueDate = dueDate;
+      review.updatedAt = nowIso();
+      changed.push(review);
+    }
+
+    previousDate = dueDate;
+  }
+
+  return changed;
+}
+
+function buildRecurringSuccessor(task: Task): Task | undefined {
+  if (task.frequency === 'once') return undefined;
+
+  const now = nowIso();
+
+  return {
+    id: newId(),
+    title: task.title,
+    frequency: task.frequency,
+    reminderTime: task.reminderTime ?? null,
+    isLearning: task.isLearning,
+    notes: task.notes,
+    completed: false,
+    dueDate: nextDueDate(task.dueDate, task.frequency),
+    createdAt: now,
+    updatedAt: now,
+    taskKind: task.isLearning ? 'learning_source' : 'standard',
+    parentTaskId: task.parentTaskId ?? task.id,
+  };
+}
+
+export async function completeTask(id: string, input: CompleteTaskInput): Promise<CompleteTaskResult> {
+  const db = await readDb();
+  const task = db.tasks.find((item) => item.id === id);
+
+  if (!task) {
+    throw new NotFoundError('Task not found.');
+  }
+
+  if (task.completed) {
+    return {
+      task,
+      createdReviews: [],
+      adjustedReviews: [],
+    };
+  }
+
+  if (input.mastery !== undefined) {
+    assertValidMastery(input.mastery);
+  }
+
+  const completedAt = nowIso();
+  const completedAtDate = toDateOnly(completedAt);
+
+  task.completed = true;
+  task.completedAt = completedAt;
+  task.updatedAt = completedAt;
+
+  const result: CompleteTaskResult = {
+    task,
+    createdReviews: [],
+    adjustedReviews: [],
+  };
+
+  if (task.taskKind === 'learning_source') {
+    const learnedContent = input.learnedContent?.trim();
+    if (!learnedContent) {
+      throw new ValidationError('learnedContent is required for learning tasks.');
+    }
+
+    const reviews = createReviewTasks({
+      sourceTask: task,
+      completionDate: completedAtDate,
+      learnedContent,
+      mastery: input.mastery,
+    });
+
+    db.tasks.push(...reviews);
+    result.createdReviews = reviews;
+  }
+
+  if (task.taskKind === 'learning_review') {
+    if (!task.seriesId) {
+      throw new ValidationError('Review task is missing seriesId.');
+    }
+
+    if (!input.mastery) {
+      throw new ValidationError('mastery is required for review tasks.');
+    }
+
+    task.mastery = input.mastery;
+    const changed = adjustPendingReviews({
+      tasks: db.tasks,
+      seriesId: task.seriesId,
+      completedReviewStep: task.reviewStep ?? 1,
+      completedAtDate,
+      mastery: input.mastery,
+    });
+    result.adjustedReviews = changed;
+  }
+
+  const nextRecurringTask = buildRecurringSuccessor(task);
+  if (nextRecurringTask) {
+    db.tasks.push(nextRecurringTask);
+    result.nextRecurringTask = nextRecurringTask;
+  }
+
+  await writeDb(db);
+
+  return result;
+}

--- a/memo-backend/src/types.ts
+++ b/memo-backend/src/types.ts
@@ -1,0 +1,57 @@
+export type TaskFrequency = 'once' | 'daily' | 'weekly' | 'monthly' | 'weekdays';
+export type MasteryLevel = 'good' | 'fair' | 'poor';
+export type TaskKind = 'standard' | 'learning_source' | 'learning_review';
+
+export interface Task {
+  id: string;
+  title: string;
+  frequency: TaskFrequency;
+  reminderTime?: string | null;
+  isLearning: boolean;
+  notes?: string;
+  completed: boolean;
+  dueDate: string;
+  createdAt: string;
+  updatedAt: string;
+  taskKind: TaskKind;
+  parentTaskId?: string | null;
+  seriesId?: string;
+  reviewStep?: number;
+  completedAt?: string;
+  learningContent?: string;
+  mastery?: MasteryLevel;
+}
+
+export interface TaskDatabase {
+  tasks: Task[];
+}
+
+export interface CreateTaskInput {
+  title: string;
+  frequency: TaskFrequency;
+  reminderTime?: string | null;
+  isLearning: boolean;
+  notes?: string;
+  dueDate: string;
+}
+
+export interface UpdateTaskInput {
+  title?: string;
+  frequency?: TaskFrequency;
+  reminderTime?: string | null;
+  isLearning?: boolean;
+  notes?: string;
+  dueDate?: string;
+}
+
+export interface CompleteTaskInput {
+  learnedContent?: string;
+  mastery?: MasteryLevel;
+}
+
+export interface CompleteTaskResult {
+  task: Task;
+  createdReviews: Task[];
+  adjustedReviews: Task[];
+  nextRecurringTask?: Task;
+}

--- a/memo-backend/src/validation.ts
+++ b/memo-backend/src/validation.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+const taskFrequencySchema = z.enum(['once', 'daily', 'weekly', 'monthly', 'weekdays']);
+const masteryLevelSchema = z.enum(['good', 'fair', 'poor']);
+
+export const listTaskQuerySchema = z.object({
+  date: z.string().optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  includeCompleted: z
+    .string()
+    .optional()
+    .transform((value) => (value === undefined ? true : value !== 'false')),
+});
+
+export const createTaskSchema = z.object({
+  title: z.string(),
+  frequency: taskFrequencySchema,
+  reminderTime: z.string().nullable().optional(),
+  isLearning: z.boolean(),
+  notes: z.string().optional(),
+  dueDate: z.string(),
+});
+
+export const updateTaskSchema = z
+  .object({
+    title: z.string().optional(),
+    frequency: taskFrequencySchema.optional(),
+    reminderTime: z.string().nullable().optional(),
+    isLearning: z.boolean().optional(),
+    notes: z.string().optional(),
+    dueDate: z.string().optional(),
+  })
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'At least one field is required.',
+  });
+
+export const completeTaskSchema = z.object({
+  learnedContent: z.string().optional(),
+  mastery: masteryLevelSchema.optional(),
+});

--- a/memo-backend/tsconfig.json
+++ b/memo-backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/memo-frontend/app/task/[id]/edit/page.tsx
+++ b/memo-frontend/app/task/[id]/edit/page.tsx
@@ -1,21 +1,49 @@
 'use client';
 
-import { useParams, notFound } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import { TaskFormPage } from '@/modules/task-form/components/TaskFormPage';
-import { loadTasks } from '@/shared/lib/storage';
-import { useMemo } from 'react';
+import { useEffect, useState } from 'react';
+import type { Task } from '@/shared/types/global';
+import { fetchTaskById } from '@/shared/lib/task-api';
 
 export default function EditTaskPage() {
   const params = useParams();
   const id = params.id as string;
+  const [task, setTask] = useState<Task | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const task = useMemo(() => {
-    const tasks = loadTasks();
-    return tasks.find((t) => t.id === id) || null;
+  useEffect(() => {
+    let mounted = true;
+
+    const load = async () => {
+      try {
+        const data = await fetchTaskById(id);
+        if (!mounted) return;
+        setTask(data);
+      } catch (e) {
+        if (!mounted) return;
+        setError(e instanceof Error ? e.message : '任务不存在或加载失败');
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      mounted = false;
+    };
   }, [id]);
 
+  if (loading) {
+    return <div className="p-6 text-sm text-gray-500">加载中...</div>;
+  }
+
   if (!task) {
-    notFound();
+    return <div className="p-6 text-sm text-red-500">{error || '任务不存在'}</div>;
   }
 
   return <TaskFormPage task={task} />;

--- a/memo-frontend/modules/task-form/components/TaskFormPage.tsx
+++ b/memo-frontend/modules/task-form/components/TaskFormPage.tsx
@@ -46,7 +46,7 @@ export function TaskFormPage({ task, initialDate }: TaskFormPageProps) {
     }
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!validate()) {
       alert('请填写任务标题');
       return;
@@ -54,18 +54,29 @@ export function TaskFormPage({ task, initialDate }: TaskFormPageProps) {
 
     const submitData = getSubmitData();
 
-    if (isEdit) {
-      updateTask(task.id, submitData);
-    } else {
-      addTask(submitData);
-    }
+    try {
+      if (isEdit) {
+        await updateTask(task.id, submitData);
+      } else {
+        await addTask(submitData);
+      }
 
-    router.push('/');
+      router.push('/');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '保存失败，请稍后重试';
+      alert(message);
+    }
   };
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (isEdit) {
-      deleteTask(task.id);
+      try {
+        await deleteTask(task.id);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : '删除失败，请稍后重试';
+        alert(message);
+        return;
+      }
     }
     router.push('/');
   };

--- a/memo-frontend/modules/task-list/hooks/useTasks.ts
+++ b/memo-frontend/modules/task-list/hooks/useTasks.ts
@@ -1,66 +1,97 @@
-import { useState, useCallback } from 'react';
-import type { Task } from '@/shared/types/global';
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import type { MasteryLevel, Task } from '@/shared/types/global';
 import {
-  loadTasks,
-  addTaskToStorage,
-  updateTaskInStorage,
-  deleteTaskFromStorage,
-} from '@/shared/lib/storage';
+  completeTask,
+  createTask,
+  fetchTasks,
+  patchTask,
+  removeTask,
+} from '@/shared/lib/task-api';
 
 type TaskInput = Omit<Task, 'id' | 'createdAt' | 'updatedAt' | 'completed'>;
 
 export function useTasks(initialDate?: string) {
-  const [tasks, setTasks] = useState<Task[]>(() => loadTasks());
+  const [tasks, setTasks] = useState<Task[]>([]);
   const [selectedDate, setSelectedDate] = useState(
     initialDate || new Date().toISOString().split('T')[0]
   );
 
-  // 按日期过滤
-  const filteredTasks = tasks.filter((task) => task.dueDate === selectedDate);
-
-  // 生成 ID
-  const generateId = () => `local_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
-
-  // 添加任务
-  const addTask = useCallback((taskData: TaskInput) => {
-    const now = new Date().toISOString();
-    const newTask: Task = {
-      ...taskData,
-      id: generateId(),
-      completed: false,
-      createdAt: now,
-      updatedAt: now,
-    };
-
-    const newTasks = addTaskToStorage(newTask);
-    setTasks(newTasks);
-    return newTask;
+  const refreshTasks = useCallback(async () => {
+    const latestTasks = await fetchTasks();
+    setTasks(latestTasks);
   }, []);
 
-  // 更新任务
-  const updateTask = useCallback((id: string, updates: Partial<Omit<Task, 'id' | 'createdAt'>>) => {
-    const fullUpdates = { ...updates, updatedAt: new Date().toISOString() };
-    const newTasks = updateTaskInStorage(id, fullUpdates);
-    setTasks(newTasks);
-  }, []);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void refreshTasks();
+  }, [refreshTasks]);
 
-  // 删除任务
-  const deleteTask = useCallback((id: string) => {
-    const newTasks = deleteTaskFromStorage(id);
-    setTasks(newTasks);
-  }, []);
+  const filteredTasks = useMemo(
+    () => tasks.filter((task) => task.dueDate === selectedDate),
+    [tasks, selectedDate]
+  );
 
-  // 切换完成状态
-  const toggleComplete = useCallback((id: string) => {
-    const task = tasks.find(t => t.id === id);
+  const addTask = useCallback(async (taskData: TaskInput) => {
+    const task = await createTask(taskData);
+    await refreshTasks();
+    return task;
+  }, [refreshTasks]);
+
+  const updateTask = useCallback(async (id: string, updates: Partial<Omit<Task, 'id' | 'createdAt'>>) => {
+    await patchTask(id, updates);
+    await refreshTasks();
+  }, [refreshTasks]);
+
+  const deleteTask = useCallback(async (id: string) => {
+    await removeTask(id);
+    await refreshTasks();
+  }, [refreshTasks]);
+
+  const toggleComplete = useCallback(async (id: string) => {
+    const task = tasks.find((t) => t.id === id);
     if (!task) return;
 
-    const newTasks = updateTaskInStorage(id, {
-      completed: !task.completed,
-      updatedAt: new Date().toISOString(),
-    });
-    setTasks(newTasks);
-  }, [tasks]);
+    if (task.completed) {
+      alert('已完成任务暂不支持取消勾选。');
+      return;
+    }
+
+    if (task.isLearning) {
+      const taskKind = task.taskKind || 'learning_source';
+
+      if (taskKind === 'learning_review') {
+        const input = window.prompt('请评估掌握度（good / okay / poor）', 'okay');
+        if (!input) return;
+
+        const normalized = input.trim().toLowerCase();
+        const masteryMap: Record<string, MasteryLevel> = {
+          good: 'good',
+          okay: 'fair',
+          fair: 'fair',
+          poor: 'poor',
+        };
+        const mastery = masteryMap[normalized];
+
+        if (!mastery) {
+          alert('请输入 good、okay 或 poor。');
+          return;
+        }
+
+        await completeTask(id, { mastery });
+      } else {
+        const learnedContent = window.prompt('请输入本次学习内容');
+        if (!learnedContent || !learnedContent.trim()) {
+          alert('学习任务完成时需要填写学习内容。');
+          return;
+        }
+        await completeTask(id, { learnedContent: learnedContent.trim() });
+      }
+    } else {
+      await completeTask(id, {});
+    }
+
+    await refreshTasks();
+  }, [refreshTasks, tasks]);
 
   return {
     tasks: filteredTasks,
@@ -71,5 +102,6 @@ export function useTasks(initialDate?: string) {
     updateTask,
     deleteTask,
     toggleComplete,
+    refreshTasks,
   };
 }

--- a/memo-frontend/shared/lib/task-api.ts
+++ b/memo-frontend/shared/lib/task-api.ts
@@ -1,0 +1,68 @@
+import type { MasteryLevel, Task } from '@/shared/types/global';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
+
+type CreateTaskInput = Omit<Task, 'id' | 'createdAt' | 'updatedAt' | 'completed'>;
+type UpdateTaskInput = Partial<Omit<Task, 'id' | 'createdAt'>>;
+
+interface CompleteTaskInput {
+  learnedContent?: string;
+  mastery?: MasteryLevel;
+}
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const message = typeof payload?.error === 'string' ? payload.error : 'Request failed.';
+    throw new Error(message);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export async function fetchTasks(): Promise<Task[]> {
+  const result = await apiFetch<{ tasks: Task[] }>('/api/tasks?includeCompleted=true');
+  return result.tasks;
+}
+
+export async function fetchTaskById(id: string): Promise<Task> {
+  const result = await apiFetch<{ task: Task }>(`/api/tasks/${id}`);
+  return result.task;
+}
+
+export async function createTask(input: CreateTaskInput): Promise<Task> {
+  const result = await apiFetch<{ task: Task }>('/api/tasks', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+  return result.task;
+}
+
+export async function patchTask(id: string, updates: UpdateTaskInput): Promise<Task> {
+  const result = await apiFetch<{ task: Task }>(`/api/tasks/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(updates),
+  });
+  return result.task;
+}
+
+export async function removeTask(id: string): Promise<void> {
+  await apiFetch<{ ok: boolean }>(`/api/tasks/${id}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function completeTask(id: string, payload: CompleteTaskInput): Promise<void> {
+  await apiFetch(`/api/tasks/${id}/complete`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}

--- a/memo-frontend/shared/types/global.ts
+++ b/memo-frontend/shared/types/global.ts
@@ -1,6 +1,7 @@
 export type TaskFrequency = 'once' | 'daily' | 'weekly' | 'monthly' | 'weekdays';
 export type SyncStatus = 'synced' | 'pending' | 'syncing' | 'failed';
 export type MasteryLevel = 'good' | 'fair' | 'poor';
+export type TaskKind = 'standard' | 'learning_source' | 'learning_review';
 
 export interface Task {
   id: string;                   // 本地 id
@@ -14,6 +15,13 @@ export interface Task {
   dueDate: string;
   createdAt: string;
   updatedAt: string;
+  taskKind?: TaskKind;
+  parentTaskId?: string | null;
+  seriesId?: string;
+  reviewStep?: number;
+  completedAt?: string;
+  learningContent?: string;
+  mastery?: MasteryLevel;
   // syncStatus: SyncStatus;       // 同步状态
   // lastSyncedAt?: string;        // 最后同步时间
 }


### PR DESCRIPTION
Implemented a full frontend-backend integration by moving task data operations from browser local storage to the new standalone API service, so the app now has a single source of truth and can reliably support memory-curve logic across sessions and clients instead of being limited to one device/browser.

The frontend now performs task CRUD and completion through HTTP endpoints, edit pages fetch task details from the backend, form submission/delete are asynchronous with error handling, and completion flows now trigger backend-driven behaviors for recurring task generation plus learning-review scheduling and mastery-based adjustment.

The backend service should be run first:

<img width="1015" height="173" alt="image" src="https://github.com/user-attachments/assets/4f525997-7ca4-4c69-86b7-ba95c913bf6b" />

Then run the frontend:

<img width="1017" height="223" alt="image" src="https://github.com/user-attachments/assets/7df895d3-b4b0-4627-9741-2ca647c81aa2" />

Tasks created on the frontend would be routed to the backend and stored in memo-backend/data/memory-curve-db.json.

<img width="1415" height="414" alt="image" src="https://github.com/user-attachments/assets/e62d00bd-a7b6-4746-b849-5faa6f9d4835" />

<img width="1062" height="508" alt="image" src="https://github.com/user-attachments/assets/cfc178a7-bd4f-4e20-8b02-5665c8bb8e8e" />
