### PR TITLE
fix: remove the usage of loadTasks

### DIFF
--- a/memo-frontend/modules/task-list/hooks/useTasks.ts
+++ b/memo-frontend/modules/task-list/hooks/useTasks.ts
@@ -12,12 +12,6 @@ type TaskInput = Omit<Task, 'id' | 'createdAt' | 'updatedAt' | 'completed'>;
 
 export function useTasks(initialDate?: string) {
   const [tasks, setTasks] = useState<Task[]>([]);
-  
-  useEffect(() => {
-    setTasks(loadTasks());
-  }, []);
-
-  //const [tasks, setTasks] = useState<Task[]>(() => loadTasks());
   const [selectedDate, setSelectedDate] = useState(
     initialDate || new Date().toISOString().split('T')[0]
   );


### PR DESCRIPTION
移除已经被删除的loadTasks方法在useTasks.ts中的调用。